### PR TITLE
Make the recv timeout shorter than the gen_server timeout

### DIFF
--- a/src/katja_connection.erl
+++ b/src/katja_connection.erl
@@ -211,7 +211,7 @@ receive_reply_tcp(Socket) ->
 
 -spec receive_reply_tcp(gen_tcp:socket(), binary()) -> {ok, term()} | {error, term()}.
 receive_reply_tcp(Socket, Buffer) ->
-  case gen_tcp:recv(Socket, 0, 5000) of
+  case gen_tcp:recv(Socket, 0, 4000) of
     {ok, BinMsg} ->
       BinMsg2 = <<Buffer/binary, BinMsg/binary>>,
       case decode_message(BinMsg2) of

--- a/src/katja_connection.erl
+++ b/src/katja_connection.erl
@@ -182,14 +182,9 @@ send_message_udp(Msg, #connection_state{host=Host, port=Port, udp_socket=Socket}
   end.
 
 connect_and_send(Msg, S=#connection_state{host=Host, port=Port}) ->
-  case connect_tcp(Host, Port) of
-    {ok, #connection_state{tcp_socket=NewSocket}} ->
-       S2 = S#connection_state{tcp_socket=NewSocket},
-       send_message_tcp(Msg, S2);
-    {error, _Reason}=E ->
-       S2 = S#connection_state{tcp_socket=undefined},
-       {E, S2}
-  end.
+  {ok, #connection_state{tcp_socket=NewSocket}} = connect_tcp(Host, Port),
+  S2 = S#connection_state{tcp_socket=NewSocket},
+  send_message_tcp(Msg, S2).
 
 -spec send_message_tcp(binary(), state()) -> {{ok, riemannpb_message()}, state()} | {{error, term()}, state()}.
 send_message_tcp(Msg, #connection_state{tcp_socket=Socket}=S) when Socket =/= undefined ->


### PR DESCRIPTION
This avoids exceptions.  Ideally I'd like to make all the gen_server
calls have infinite timeouts and rely on the underlying gen_(tcp|udp)
timeouts but that's a bit more work.

cc @AeroNotix
